### PR TITLE
SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR switch and updated the README.md with the documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,95 @@
----
-title: NavigationBar
-description: Control the device navigation bar.
----
+# cordova-plugin-navigationbar-color
+
+> The `NavigationBar` object provides some functions to control the Android device navigation bar.
+
+## Installation
+
+    cordova plugin add cordova-plugin-navigationbar-color
+
+Preferences
+-----------
+
+#### config.xml
+
+-  __NavigationBarBackgroundColor__ (color hex string, default value __#000000__). Color of navigation bar.
+
+```xml
+<preference name="NavigationBarBackgroundColor" value="#000000" />
+```
+        
+
+- __NavigationBarLigth__ (boolean, defaults to __false__). Change the color of the buttons in the navigation bar to black, use in light colors of the navigation bar (Android 8.0 or higher).
+
+```xml
+<preference name="NavigationBarLigth" value="true" />
+```
+
+Methods
+-------
+This plugin defines global `NavigationBar` object.
+
+Although in the global scope, it is not available until after the `deviceready` event.
+
+```js
+document.addEventListener("deviceready", onDeviceReady, false);
+
+function onDeviceReady()
+{
+    console.log(NavigationBar);
+}
+```
+
+#### NavigationBar.backgroundColorByHexString
+
+Set color of navigation bar by hex string.
+
+```js
+NavigationBar.backgroundColorByHexString(String colorHex, Boolean ligthNavigationBar = false);
+```
+
+-  __colorHex__ Color hex string. Set the color of navigation bar.
+
+-  __ligthNavigationBar__ Change the color of the buttons in the navigation bar to black, use in light colors of the navigation bar (Android 8.0 or higher).
+
+#### NavigationBar.backgroundColorByName
+
+Set color of navigation bar by color name.
+
+```js
+NavigationBar.backgroundColorByName(String colorName, Boolean ligthNavigationBar = false);
+```
+
+-  __colorName__ Color name. Set the color of navigation bar.
+- - __Possible values__
+- - `black`: Equals #000000
+- - `darkGray`: Equals #A9A9A9
+- - `lightGray`: Equals #D3D3D3
+- - `white`: Equals #FFFFFF
+- - `gray`: Equals #808080
+- - `red`: Equals #FF0000
+- - `green`: Equals #00FF00
+- - `blue`: Equals #0000FF
+- - `cyan`: Equals #00FFFF
+- - `yellow`: Equals #FFFF00
+- - `magenta`: Equals #FF00FF
+- - `orange`: Equals #FFA500
+- - `purple`: Equals #800080
+- - `brown`: Equals #A52A2A
+
+-  __ligthNavigationBar__ Change the color of the buttons in the navigation bar to black, use in light colors of the navigation bar (Android 8.0 or higher).
+
+#### NavigationBar.hide
+
+Hide the navigation bar.
+
+```js
+NavigationBar.hide();
+```
+
+#### NavigationBar.show
+
+Shows the navigation bar.
+
+```js
+NavigationBar.show();
+```

--- a/src/android/NavigationBar.java
+++ b/src/android/NavigationBar.java
@@ -59,8 +59,8 @@ public class NavigationBar extends CordovaPlugin {
                 Window window = cordova.getActivity().getWindow();
                 window.clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
 
-                // Read 'NavigationBarBackgroundColor' from config.xml, default is #000000.
-                setNavigationBarBackgroundColor(preferences.getString("NavigationBarBackgroundColor", "#000000"));
+                // Read 'NavigationBarBackgroundColor' and 'NavigationBarLigth' from config.xml, default is #000000.
+                setNavigationBarBackgroundColor(preferences.getString("NavigationBarBackgroundColor", "#000000"), preferences.getBoolean("NavigationBarLigth", false));
             }
         });
     }
@@ -153,7 +153,7 @@ public class NavigationBar extends CordovaPlugin {
                 @Override
                 public void run() {
                     try {
-                        setNavigationBarBackgroundColor(args.getString(0));
+                        setNavigationBarBackgroundColor(args.getString(0), args.getBoolean(1));
                     } catch (JSONException ignore) {
                         LOG.e(TAG, "Invalid hexString argument, use f.i. '#777777'");
                     }
@@ -165,12 +165,26 @@ public class NavigationBar extends CordovaPlugin {
         return false;
     }
 
-    private void setNavigationBarBackgroundColor(final String colorPref) {
+    private void setNavigationBarBackgroundColor(final String colorPref, Boolean ligthNavigationBar) {
+
+        ligthNavigationBar = ligthNavigationBar == null ? false : ligthNavigationBar;
+
         if (Build.VERSION.SDK_INT >= 21) {
             if (colorPref != null && !colorPref.isEmpty()) {
                 final Window window = cordova.getActivity().getWindow();
-                
-                window.getDecorView (). setSystemUiVisibility (0x80000000 | 0x00000010); // FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS | SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
+                int uiOptions = window.getDecorView().getSystemUiVisibility();
+                             
+                // 0x80000000 FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS
+                // 0x00000010 SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
+
+                uiOptions = uiOptions | 0x80000000;
+
+                if(Build.VERSION.SDK_INT >= 26 && ligthNavigationBar)
+                    uiOptions = uiOptions | 0x00000010;
+                else
+                    uiOptions = uiOptions & ~0x00000010;
+
+                window.getDecorView().setSystemUiVisibility(uiOptions);
                 
                 try {
                     // Using reflection makes sure any 5.0+ device will work without having to compile with SDK level 21

--- a/www/navigationbar.js
+++ b/www/navigationbar.js
@@ -43,11 +43,11 @@ var NavigationBar = {
 
     isVisible: true,
 
-    backgroundColorByName: function (colorname) {
-        return NavigationBar.backgroundColorByHexString(namedColors[colorname]);
+    backgroundColorByName: function (colorname, ligthNavigationBar) {
+        return NavigationBar.backgroundColorByHexString(namedColors[colorname], ligthNavigationBar);
     },
 
-    backgroundColorByHexString: function (hexString) {
+    backgroundColorByHexString: function (hexString, ligthNavigationBar) {
         if (hexString.charAt(0) !== "#") {
             hexString = "#" + hexString;
         }
@@ -57,7 +57,9 @@ var NavigationBar = {
             hexString = "#" + split[1] + split[1] + split[2] + split[2] + split[3] + split[3];
         }
 
-        exec(null, null, "NavigationBar", "backgroundColorByHexString", [hexString]);
+        ligthNavigationBar = (ligthNavigationBar) ? true : false;
+
+        exec(null, null, "NavigationBar", "backgroundColorByHexString", [hexString, ligthNavigationBar]);
     },
 
     hide: function () {


### PR DESCRIPTION
Hi.

I added an interuptor to activate and deactivate SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR, in this way it can be deactivated for dark colors and activated for light colors, since otherwise the buttons of the navigation bar are sometimes not visible.

I have also updated README.md with the plugin documentation.

A greeting.