### PR TITLE
Fix typo "ligth" to "light", related to #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Preferences
 ```
         
 
-- __NavigationBarLigth__ (boolean, defaults to __false__). Change the color of the buttons in the navigation bar to black, use in light colors of the navigation bar (Android 8.0 or higher).
+- __NavigationBarLight__ (boolean, defaults to __false__). Change the color of the buttons in the navigation bar to black, use in light colors of the navigation bar (Android 8.0 or higher).
 
 ```xml
-<preference name="NavigationBarLigth" value="true" />
+<preference name="NavigationBarLight" value="true" />
 ```
 
 Methods
@@ -44,19 +44,19 @@ function onDeviceReady()
 Set color of navigation bar by hex string.
 
 ```js
-NavigationBar.backgroundColorByHexString(String colorHex, Boolean ligthNavigationBar = false);
+NavigationBar.backgroundColorByHexString(String colorHex, Boolean lightNavigationBar = false);
 ```
 
 -  __colorHex__ Color hex string. Set the color of navigation bar.
 
--  __ligthNavigationBar__ Change the color of the buttons in the navigation bar to black, use in light colors of the navigation bar (Android 8.0 or higher).
+-  __lightNavigationBar__ Change the color of the buttons in the navigation bar to black, use in light colors of the navigation bar (Android 8.0 or higher).
 
 #### NavigationBar.backgroundColorByName
 
 Set color of navigation bar by color name.
 
 ```js
-NavigationBar.backgroundColorByName(String colorName, Boolean ligthNavigationBar = false);
+NavigationBar.backgroundColorByName(String colorName, Boolean lightNavigationBar = false);
 ```
 
 -  __colorName__ Color name. Set the color of navigation bar.
@@ -76,7 +76,7 @@ NavigationBar.backgroundColorByName(String colorName, Boolean ligthNavigationBar
 - - `purple`: Equals #800080
 - - `brown`: Equals #A52A2A
 
--  __ligthNavigationBar__ Change the color of the buttons in the navigation bar to black, use in light colors of the navigation bar (Android 8.0 or higher).
+-  __lightNavigationBar__ Change the color of the buttons in the navigation bar to black, use in light colors of the navigation bar (Android 8.0 or higher).
 
 #### NavigationBar.hide
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-navigationbar-color",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "description": "Cordova NavigationBar Plugin",
   "cordova": {
     "id": "cordova-plugin-navigationbar-color",

--- a/src/android/NavigationBar.java
+++ b/src/android/NavigationBar.java
@@ -59,8 +59,8 @@ public class NavigationBar extends CordovaPlugin {
                 Window window = cordova.getActivity().getWindow();
                 window.clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
 
-                // Read 'NavigationBarBackgroundColor' and 'NavigationBarLigth' from config.xml, default is #000000.
-                setNavigationBarBackgroundColor(preferences.getString("NavigationBarBackgroundColor", "#000000"), preferences.getBoolean("NavigationBarLigth", false));
+                // Read 'NavigationBarBackgroundColor' and 'NavigationBarLight' from config.xml, default is #000000.
+                setNavigationBarBackgroundColor(preferences.getString("NavigationBarBackgroundColor", "#000000"), preferences.getBoolean("NavigationBarLight", false));
             }
         });
     }
@@ -165,9 +165,9 @@ public class NavigationBar extends CordovaPlugin {
         return false;
     }
 
-    private void setNavigationBarBackgroundColor(final String colorPref, Boolean ligthNavigationBar) {
+    private void setNavigationBarBackgroundColor(final String colorPref, Boolean lightNavigationBar) {
 
-        ligthNavigationBar = ligthNavigationBar == null ? false : ligthNavigationBar;
+        lightNavigationBar = lightNavigationBar == null ? false : lightNavigationBar;
 
         if (Build.VERSION.SDK_INT >= 21) {
             if (colorPref != null && !colorPref.isEmpty()) {
@@ -179,7 +179,7 @@ public class NavigationBar extends CordovaPlugin {
 
                 uiOptions = uiOptions | 0x80000000;
 
-                if(Build.VERSION.SDK_INT >= 26 && ligthNavigationBar)
+                if(Build.VERSION.SDK_INT >= 26 && lightNavigationBar)
                     uiOptions = uiOptions | 0x00000010;
                 else
                     uiOptions = uiOptions & ~0x00000010;

--- a/www/navigationbar.js
+++ b/www/navigationbar.js
@@ -43,11 +43,11 @@ var NavigationBar = {
 
     isVisible: true,
 
-    backgroundColorByName: function (colorname, ligthNavigationBar) {
-        return NavigationBar.backgroundColorByHexString(namedColors[colorname], ligthNavigationBar);
+    backgroundColorByName: function (colorname, lightNavigationBar) {
+        return NavigationBar.backgroundColorByHexString(namedColors[colorname], lightNavigationBar);
     },
 
-    backgroundColorByHexString: function (hexString, ligthNavigationBar) {
+    backgroundColorByHexString: function (hexString, lightNavigationBar) {
         if (hexString.charAt(0) !== "#") {
             hexString = "#" + hexString;
         }
@@ -57,9 +57,9 @@ var NavigationBar = {
             hexString = "#" + split[1] + split[1] + split[2] + split[2] + split[3] + split[3];
         }
 
-        ligthNavigationBar = (ligthNavigationBar) ? true : false;
+        lightNavigationBar = (lightNavigationBar) ? true : false;
 
-        exec(null, null, "NavigationBar", "backgroundColorByHexString", [hexString, ligthNavigationBar]);
+        exec(null, null, "NavigationBar", "backgroundColorByHexString", [hexString, lightNavigationBar]);
     },
 
     hide: function () {


### PR DESCRIPTION
- Fix typo "light" to "light"
- Increment version 0.0.9 to 0.1.0 
- Breaking change, its needed fix typo `NavigationBarLigth` to `NavigationBarLight`
